### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
 jobs:
   build:
     name: Lint & Build


### PR DESCRIPTION
Potential fix for [https://github.com/dennykjohn/data-syncher-ui/security/code-scanning/1](https://github.com/dennykjohn/data-syncher-ui/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block specifying the required minimum privilege at the correct scope. Since none of the current jobs or steps require write access to repository contents, the safest starting point is `permissions: contents: read`. This block should be added either at the root of the workflow (above `jobs:`), which will apply to all jobs, or directly within the specific job (`build:`) if you prefer job-level granularity.  
In this case, adding at the root is simpler and recommended: insert the following between the triggers (`on:`) and the `jobs:` key in `.github/workflows/ci.yml`. No new imports or methods are needed.  

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
